### PR TITLE
Add k8s deployment ymls for bazelremote

### DIFF
--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote-svc.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote-svc.yml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
     name: bazelremote-svc
-    namespace: bazelremote-ns # Ensure this matches the namespace name
+    namespace: bazelremote-ns
 spec:
     selector:
-      app.kubernetes.io/name: bazelremote # This matches the labels in your bazelremote Deployment
+      app: bazelremote
     ports:
     - protocol: TCP
       port: 9092

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote-svc.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote-svc.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: bazelremote-svc
+    namespace: bazelremote-ns # Ensure this matches the namespace name
+spec:
+    selector:
+      app.kubernetes.io/name: bazelremote # This matches the labels in your bazelremote Deployment
+    ports:
+    - protocol: TCP
+      port: 9092
+      targetPort: 9092
+      name: grpc
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http-default
+    type: ClusterIP # For internal cluster access

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
@@ -52,7 +52,7 @@ spec:
         - name: BAZEL_REMOTE_DIR
           value: /data
         - name: BAZEL_REMOTE_MAX_SIZE
-          value: "10000"
+          value: "1000" #in GiB, i.e. 1tb
         - name: BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION
           value: true
         volumeMounts:

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
@@ -1,0 +1,61 @@
+# This configuration has been reported as working with k8s >= 1.24
+# adapted from https://github.com/buchgr/bazel-remote/blob/master/examples/kubernetes.yml
+# kubectl create namespace bazelremote-ns
+# kubectl apply -f azure-linux-scale-rocm-bazelremote.yml -n bazelremote-ns
+# kubectl apply -f azure-linux-scale-rocm-bazelremote-svc.yml -n bazelremote-ns 
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bazelremote
+  labels:
+    app: bazelremote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bazelremote
+  template:
+    metadata:
+      labels:
+        app: bazelremote
+    spec:
+      containers:
+      - name: bazel-remote-cache
+        image: buchgr/bazel-remote-cache:latest
+        ports:
+          - containerPort: 9092
+            name: grpc
+            protocol: TCP
+          - containerPort: 8080
+            name: http-default
+            protocol: TCP
+        livenessProbe:
+            grpc:
+              service: /grpc.health.v1.Health/Check
+              port: 9092
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+        readinessProbe:
+            grpc:
+              service: /grpc.health.v1.Health/Check
+              port: 9092
+            failureThreshold: 3
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 10
+        env:
+        # Set bazel-remote configuration value here...
+        - name: BAZEL_REMOTE_DIR
+          value: /data
+        - name: BAZEL_REMOTE_MAX_SIZE
+          value: "10000"
+        volumeMounts:
+        - name: cache-volume
+          mountPath: /data
+      volumes:
+      - name: cache-volume
+        emptyDir: {} #As a test, using temporary disks

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
@@ -53,6 +53,8 @@ spec:
           value: /data
         - name: BAZEL_REMOTE_MAX_SIZE
           value: "10000"
+        - name: BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION
+          value: true
         volumeMounts:
         - name: cache-volume
           mountPath: /data

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
@@ -62,6 +62,8 @@ spec:
           value: "1000" #in GiB, i.e. 1tb
         - name: BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION
           value: "true"
+        - name: BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS
+          value: "true"
         volumeMounts:
         - name: cache-volume
           mountPath: /data

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
@@ -54,7 +54,7 @@ spec:
         - name: BAZEL_REMOTE_MAX_SIZE
           value: "1000" #in GiB, i.e. 1tb
         - name: BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION
-          value: true
+          value: "true"
         volumeMounts:
         - name: cache-volume
           mountPath: /data

--- a/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
+++ b/config-files/rocm/azure-linux-scale-rocm-bazelremote.yml
@@ -20,6 +20,13 @@ spec:
       labels:
         app: bazelremote
     spec:
+      nodeSelector:
+        app: bazelremotelabel
+      tolerations:
+      - key: "app"
+        operator: "Equal"
+        value: "bazelremotetaint"
+        effect: "NoSchedule"
       containers:
       - name: bazel-remote-cache
         image: buchgr/bazel-remote-cache:latest


### PR DESCRIPTION
PoC of bazel remote service setup for linux rocm runners in `Saiscale` cluster.
Still needs to be productionized, and moved to windows.

Ran these commands to setup on SaiScale k8s cluster
```
kubectl create namespace bazelremote-ns
kubectl apply -f azure-linux-scale-rocm-bazelremote.yml -n bazelremote-ns
kubectl apply -f azure-linux-scale-rocm-bazelremote-svc.yml -n bazelremote-ns
```