### PR TITLE
Add ymls to deploy nexus/choco/nuget cache server

### DIFF
--- a/windows-config-files/azure-windows-scale-rocm-nexus-deployment.yml
+++ b/windows-config-files/azure-windows-scale-rocm-nexus-deployment.yml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexus
+  namespace: nexus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nexus
+  template:
+    metadata:
+      labels:
+        app: nexus
+    spec:
+      initContainers:
+      - name: volume-mount-hack
+        image: busybox
+        command: ["sh", "-c", "chown -R 200:200 /nexus-data /opt/sonatype/sonatype-work"]
+        volumeMounts:
+          - name: nexus-data
+            mountPath: /nexus-data
+            subPath: nexus-data
+          - name: nexus-data
+            mountPath: /opt/sonatype/sonatype-work
+            subPath: sonatype-work
+      containers:
+        - name: nexus
+          image: sonatype/nexus3:latest
+          ports:
+            - containerPort: 8081
+          volumeMounts:
+            - name: nexus-data
+              mountPath: /nexus-data
+              subPath: nexus-data
+            - name: nexus-data
+              mountPath: /opt/sonatype/sonatype-work
+              subPath: sonatype-work
+      volumes:
+        - name: nexus-data
+          persistentVolumeClaim:
+            claimName: nexus-pvc

--- a/windows-config-files/azure-windows-scale-rocm-nexus-pvc.yml
+++ b/windows-config-files/azure-windows-scale-rocm-nexus-pvc.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nexus-pvc
+  namespace: nexus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi  # Adjust size as needed, should use p10
+  storageClassName: "managed-csi-premium"  # Azure Disk CSI driver

--- a/windows-config-files/azure-windows-scale-rocm-nexus-svc.yml
+++ b/windows-config-files/azure-windows-scale-rocm-nexus-svc.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nexus-service
+  namespace: nexus
+spec:
+  selector:
+    app: nexus
+  ports:
+    - protocol: TCP
+      port: 8081
+      targetPort: 8081
+  type: ClusterIP #changed from Loadbalancer for internal only


### PR DESCRIPTION
Adding a cache server to `win-runner-large` to help resolve rate limiting issues from `Install requirements` step in TheRock CI

Following this guide with modifications for Azure Kubernetes Service.
https://www.geeksforgeeks.org/devops/setup-latest-nexus-oss-on-kubernetes/

In summary
```haskell
kubectl create namespace nexus
kubectl apply -f azure-windows-scale-rocm-nexus-pvc.yml
kubectl apply -f azure-windows-scale-rocm-nexus-deployment.yml
kubectl apply -f azure-windows-scale-rocm-nexus-svc.yml
```

Needed this fix https://stackoverflow.com/a/52687515 to prevent 

the following issue
kubectl logs nexus-86bb5ff889-b6545 -n nexus
```haskell
...
2025-10-10 21:39:11,715+0000 ERROR [main] *SYSTEM org.springframework.boot.SpringApplication - Application run failed
java.lang.IllegalStateException: java.lang.IllegalStateException: Logback configuration error detected:
ERROR in ch.qos.logback.core.rolling.RollingFileAppender[logfile] - Failed to create parent directories for [/opt/sonatype/sonatype-work/nexus3/log/nexus.log]
ERROR in ch.qos.logback.core.rolling.RollingFileAppender[logfile] - openFile(/opt/sonatype/sonatype-work/nexus3/log/nexus.log,true) call failed. java.io.FileNotFoundExcept
...
```


```
kubectl get svc --namespace nexus                         
NAME            TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
nexus-service   ClusterIP   10.0.167.96   <none>        8081/TCP   10m
```

To access from local dev machine try using this:
```haskell
kubectl port-forward service/nexus-service 8081:8081 -n nexus
```

but if windows complains
```haskell
> kubectl port-forward service/nexus-service 8081:8081 -n nexus
Unable to listen on port 8081: Listeners failed to create with the following errors: [unable to create listener: Error listen tcp4 127.0.0.1:8081: bind: An attempt was made to access a socket in a way forbidden by its access permissions. unable to create listener: Error listen tcp6 [::1]:8081: bind: An attempt was made to access a socket in a way forbidden by its access permissions.]  
error: unable to listen on any of the requested ports: [{8081 8081}]
> kubectl port-forward service/nexus-service 8443:8081 -n nexus
Forwarding from 127.0.0.1:8443 -> 8081
Forwarding from [::1]:8443 -> 8081
```


